### PR TITLE
chore: Reduce docker image size.

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,3 +22,5 @@ jobs:
             fetch-depth: 0
       - name: Check version number consistency
         run: ./scripts/check-pr.sh
+      - name: Check that the image can be successfully built
+        run: docker build .

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.56-0.2
+
+### Changed
+
+- The bundled `cargo-deny` now links against the system OpenSSL rather than
+  its own bundled copy.
+
+### Removed
+
+- The base image now derives from the "slim" debian variant, meaning that
+  a lot of system tools have been removed. For example, `curl` is no longer
+  present by default in the image.
+
 ## 1.56-0.1
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,33 @@
 #
-# Configures a Rust and Cargo dev environment with the
-# specific tools needed for working in this repo.
+# Configures a Rust and Cargo dev environment with the specific
+# tools needed for working on harrison.ai Rust projects.
 #
-FROM rust:1.56.1
+FROM rust:1.56.1-slim
+
+# Install extra system dependencies not included in the slim base image.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends \
+    # For helping to build some Rust crates.
+    libssl-dev \
+    pkg-config \
+    # For cross-compilation to AWS Graviton2.
+    gcc-aarch64-linux-gnu \
+    libc-dev-arm64-cross \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # General dev tools.
 RUN rustup component add rustfmt
 RUN rustup component add clippy
 
 # Used for dependency license and security checks.
-RUN cargo install --version="0.10.1" cargo-deny
+# Disabling default features lets it use the system ssl library,
+# which should reduce overall size of the docker image.
+RUN cargo install --version="0.10.1" --no-default-features cargo-deny \
+  && rm -rf "$CARGO_HOME/registry"
 
-# Cross-compilation support for AWS Graviton2 processors.
-RUN apt-get update && apt-get install -y gcc-aarch64-linux-gnu && apt-get clean
+# Configure cross-compilation support for AWS Graviton2 processors.
+# We use musl to help produce smaller docker images.
 RUN rustup target add aarch64-unknown-linux-musl
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=aarch64-linux-gnu-gcc
 


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

This commit reduces the docker image size from around 2.2GB to
around 1.5GB by:

  - Using the "slim" Rust image as a base

  - Cleaning up some cargo build artifacts

There are probably still more size reductions to be had, but it's
a good start.

## Why

It might slightly speed things up in CI, but mostly it will make us feel a bit better about the (still pretty big) size of the image.

## Notes

I was delighted to find `docker history <image>` which shows you the layers that make up an image and the size of each one. This was what led me to find that the install of `cargo-deny` was leaving behind a lot of build artifacts.

The next biggest contributor to the size of the image here is `apt-get install gcc-aarch64-linux-gnu`, which adds several hundred MB. There may be a more minimal set of tools that we can get away with installing there, but that's an adventure for another day.

I've locally tested the new image to make sure it can still build the modelmill-catalogue repo, which it can.