### PR TITLE
feat: Add cargo-about for generating license info.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.56-0.4
+
+- Added `cargo-about` for generating a license file describing the
+  open-source dependencies used in a project.
+- Updated `cargo-deny` to v0.11.0. This is a semver-breaking change
+  for `cargy-deny` because it updated its minimum supported Rust version
+  to 1.561, but we're already on that version of Rust anyway so it's
+  not semver-breaking for this docker image.
+
 ## 1.56-0.3
 
 - Added x86_64-unknown-linux-musl cargo target support.

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,7 +26,12 @@ RUN rustup component add clippy
 # Used for dependency license and security checks.
 # Disabling default features lets it use the system ssl library,
 # which should reduce overall size of the docker image.
-RUN cargo install --version="0.10.1" --no-default-features cargo-deny \
+RUN cargo install --version="0.11.0" --no-default-features cargo-deny \
+  && rm -rf "$CARGO_HOME/registry"
+
+# Used for generating license files for distribution to consumers,
+# which may be required to compliance with some open-source licenses.
+RUN cargo install --version="0.4.3" cargo-about \
   && rm -rf "$CARGO_HOME/registry"
 
 # Configure cross-compilation support for AWS Graviton2 processors,


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

* Added `cargo-about`.
* Updated `cargo-deny` version while I was in here.

## Why

This is in service of https://harrison-ai.atlassian.net/browse/MOD-176, generating a license summary file for the study deletion tool. It seems worth adding to the Rust tooling image so that we have a standard way of doing this for future projects.
