### PR TITLE
chore: Speed up image build time for `cargo install`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.56-0.5
+
+- Sped up build time of the docker image by sharing build artifacts
+  between runs of `cargo install`.
+
 ## 1.56-0.4
 
 - Added `cargo-about` for generating a license file describing the


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Share intermediate build artifacts between runs of `cargo install`.

## Why

I noticed that the image build time for #5 was painfully long and wanted to see if there were any quick wins. This change saves about a minute and a half off the time to build the docker image in my local testing, because `cargo-deny` and `cargo-about` share a lot of dependencies.

## Concerns

This is going to create a spurious version bump in the docker image, but 🤷🏻‍♂️. If the global stockpile of version numbers starts running low we can figure out a more nuanced system for publishing from this repo.