### PR TITLE
feat: add `cargo-release` to the docker image.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.57-0.2
+
+- Added `cargo-release` to the image, for easily cutting releases.
+
 ## 1.57-0.1
 
 - Updated Rust version to `1.57.0`.

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,8 @@ RUN export CARGO_TARGET_DIR=/tmp/cargo-install-target \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
   && cargo install --version="0.4.3" cargo-about \
+  # cargo-release: used for cutting releases.
+  && cargo install --version="0.19.3" cargo-release \
   # Remove temporary files from the final image.
   && rm -rf "$CARGO_HOME/registry" /tmp/cargo-install-target
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The docker image provides:
   for deployment to AWS
 * Pre-configured components and settings to cross-compile static binaries for x86\_64-unknown-linux targets,
   with zlib and openssl statically compiled.
-* [`cargo-deny`](https://embarkstudios.github.io/cargo-deny/) and some default
-  configuration for checking dependency licenses and security warnings.
+* Useful project-lifecycle-management tools such as `cargo deny` for auditing
+  dependency licenses, `cargo about` for generating a license summary, and
+  `cargo release` for cutting releases.
 * A custom `cargo hai-all-checks` command to easily run our standard suite of
   quality checks from a CI environment.
 


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Added `cargo release` to the pre-installed packages in the docker image.

## Why

We will be using it for releases, having it available for default will help us standardize on some patterns for doing so.

