### PR TITLE
fix: set default linker in environment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.62-1.2
+
+- Fix linker errors when building `[[bin]]` targets, by explicitly setting the
+  appropriate linker in environment variables.
+
 ## 1.62-1.1
 
 - Updated Rust version to `1.62.1`

--- a/Dockerfile
+++ b/Dockerfile
@@ -128,6 +128,10 @@ RUN tar -xzf openssl-${SSL_VER}.tar.gz && \
 
 ENV CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
     CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
+    AR_x86_64_unknown_linux_musl=x86_64-linux-gnu-ar \
+    AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=${MUSL_PREFIX}/amd64 \
     AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=${MUSL_PREFIX}/arm64
 
@@ -159,10 +163,6 @@ RUN echo "[build]\ntarget=\"`./docker-target-triple`\"" > ${CARGO_HOME}/config.t
 
 # Build some helpful extra Rust utilities.
 #
-# It seems that `cargo install` needs a bit of extra help in order to cross-compile,
-# which is fair enough, that's not really what it's for. But it works, with some help
-# from $RUSTFLAGS.
-#
 # The use of `sharing=locked` here is to prevent two instances of the install from updating
 # the local registry cache at the same time, which can cause one to fail. Ideally we would
 # only hold the lock while updating the registry cache, rather than while doing the whole
@@ -171,7 +171,6 @@ RUN echo "[build]\ntarget=\"`./docker-target-triple`\"" > ${CARGO_HOME}/config.t
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
-  export RUSTFLAGS="-C linker=rust-lld" && \
   # cargo-deny: used for dependency license and security checks.
   # Using `--no-default-features` prevents it trying to compile its own openssl.
   cargo install --version="0.12.1" --no-default-features cargo-deny && \
@@ -231,6 +230,8 @@ ENV CC_x86_64_unknown_linux_musl=x86_64-linux-musl-gcc \
     CC_aarch64_unknown_linux_musl=aarch64-linux-musl-gcc \
     AR_x86_64_unknown_linux_musl=x86_64-linux-gnu-ar \
     AR_aarch64_unknown_linux_musl=aarch64-linux-gnu-ar \
+    CARGO_TARGET_X86_64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld \
+    CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER=rust-lld \
     X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=${MUSL_PREFIX}/amd64 \
     AARCH64_UNKNOWN_LINUX_MUSL_OPENSSL_DIR=${MUSL_PREFIX}/arm64
 

--- a/test_project/Cargo.toml
+++ b/test_project/Cargo.toml
@@ -3,6 +3,14 @@ name = "test_project"
 version = "0.1.0"
 edition = "2021"
 
+[lib]
+name = "test_project"
+path = "src/lib.rs"
+
+[[bin]]
+name = "test-project"
+path = "src/main.rs"
+
 [dependencies]
 # These dependencies are not actually used by the test program, they're here
 # to check that our toolchain can successfully build them.

--- a/test_project/src/main.rs
+++ b/test_project/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Ok!");
+}


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Explicitly set environment variables to use `rust-lld` as the linker, which seems to be better-behaved when cross-compiling bin targets.

## Why

This helps ensure that `[[bin]]` targets can link successfully, ensuring that other consumers don't hit the errors that @oliverdaff uncovered and fixed in https://github.com/harrison-ai/hai-annotate/pull/46.
