### PR TITLE
feat: add cargo-make to the docker image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
-## 1.63-2.0
+## 1.63-1.1
 
 - Added `cargo-make` to the image, for defining dev & build tasks.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 but version numbers for this repo and a little complicated because they track
-both the Rust version and our own changes no top; consule [`./README.md`] for details.
+both the Rust version and our own changes no top; consult [`./README.md`] for details.
 
 Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
+
+## 1.63-2.0
+
+- Added `cargo-make` to the image, for defining dev & build tasks.
 
 ## 1.63-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,8 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
   cargo install --version="0.5.1" cargo-about && \
+  # cargo-make: used for defining dev & build tasks.
+  cargo install --version="0.36.0" cargo-make && \
   # cargo-release: used for cutting releases.
   cargo install --version="0.21.0" cargo-release
 
@@ -244,6 +246,7 @@ COPY --from=builder ${CARGO_HOME}/config.toml ${CARGO_HOME}/config.toml
 COPY --from=builder \
   ${CARGO_HOME}/bin/cargo-deny \
   ${CARGO_HOME}/bin/cargo-about \
+  ${CARGO_HOME}/bin/cargo-make \
   ${CARGO_HOME}/bin/cargo-release \
   ${CARGO_HOME}/bin/
 


### PR DESCRIPTION
## Related Tasks

n/a

## Depends on

n/a

## What

Added [cargo-make](https://github.com/sagiegurari/cargo-make), often used in rust projects instead of `make`.

## Why

New projects may wish to adopt `cargo-make` instead of `make`

## Concerns

n/a

## Notes

n/a