### PR TITLE
chore: Update rust version to 1.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
-## 1.64.0
+## 1.64-1.0
 
 - Updated Rust version to `1.64.0`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.64.0
+
+- Updated Rust version to `1.64.0`
+
 ## 1.63-1.1
 
 - Added `cargo-make` to the image, for defining dev & build tasks.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.63.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.64.0-slim AS builder
 
 WORKDIR /build
 
@@ -195,7 +195,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.63.0-slim
+FROM rust:1.64.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/README.md
+++ b/README.md
@@ -80,6 +80,14 @@ To build the image and publish it to dockerhub:
 make publish
 ```
 
+### Troubleshooting
+
+Ubuntu 22.04 require some packages to run buildx
+
+```sh
+sudo apt-get install binfmt-support qemu-user-static
+```
+
 ## Tags and Versioning
 
 In an attempt to minimise possible confusion for users, the docker image version


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

chore: Update the Rust to the most recent version
docs: Include dependency instructions for Ubuntu

## Why

Keep the dependencies up to date.

## Concerns

Would the update affect other repositories?

## Notes
N/A

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.