### PR TITLE
chore: Update Rust to 1.65

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.65-1.0
+
+- Updated Rust version to `1.65.0`
+
 ## 1.64-1.0
 
 - Updated Rust version to `1.64.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.64.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.65.0-slim AS builder
 
 WORKDIR /build
 
@@ -195,7 +195,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.64.0-slim
+FROM rust:1.65.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

chore: Update the Rust to the most recent version

## Why

Keep the dependencies up to date.
