### PR TITLE
chore: publish to ghcr instead of dockerhub

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v3
 
@@ -35,11 +38,12 @@ jobs:
           restore-keys: |
             docker-buildx-
 
-      - name: Log in to Docker Hub
+      - name: Log in to Github Container Registry
         uses: docker/login-action@d398f07826957cd0a18ea1b059cf1207835e60bc
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and publish the images
         run: make publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 
+## 1.67-1.1
+
+- Migrate from Dockerhub to Github Container Registry
+
 ## 1.67-1.0
 
 - Updated Rust version to `1.67.1`

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .DEFAULT_GOAL := help
 
-IMAGE="harrisonai/rust"
+IMAGE="ghcr.io/harrison-ai/rust"
 
 # Integrate docker cache with github actions.
 BUILDX_CACHE_FROM =

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ To locally build and test the image on both supported platforms:
 make test
 ```
 
-To build the image and publish it to dockerhub:
+To build the image and publish it to github container registry:
 
 ```sh
 make publish
@@ -103,7 +103,7 @@ some version in the `1.56` series, and be the third release of our customization
 on top of that series.
 
 Every commit merged to `main` in this repo creates a new version that is automatically
-built and pushed to dockerhub, with version number updated according to the following
+built and pushed to github container registry, with version number updated according to the following
 rules:
 
 * If the change were purely additive (e.g. installing some additional tools, or a new

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Rust build and development tooling for harrison.ai
 
-This repository builds the [`harrisonai/rust`](https://hub.docker.com/r/harrisonai/rust)
+This repository builds the [`ghcr.io/harrison-ai/rust`](https://github.com/harrison-ai/dataeng-tooling-rust/pkgs/container/rust)
 docker image, a convenient collection of Rust build and development tooling
 for working with Rust-based projects in the harrison.ai Data Engineering team.
 
@@ -30,7 +30,7 @@ docker run
     # Run commands in your current working directory
     --workdir /app
     # Use the published rust tooling image
-    harrisonai/rust
+    ghcr.io/harrison-ai/rust
     # To run various cargo build commands
     cargo build
 ```
@@ -42,7 +42,7 @@ like this:
 ```
 services:
   cargo:
-    image: harrisonai/rust:{version-tag}
+    image: ghcr.io/harrison-ai/rust:{version-tag}
     entrypoint: cargo
     volumes:
       - '~/.cargo/registry:/usr/local/cargo/registry'
@@ -93,12 +93,12 @@ sudo apt-get install binfmt-support qemu-user-static
 In an attempt to minimise possible confusion for users, the docker image version
 reflects the underlying Rust version down to semver-minor level and appends a
 separate version number for the customizations that we layer on top. The general
-form is `harrisonai/rust:M.NN-X.Y` where:
+form is `ghcr.io/harrison-ai/rust:M.NN-X.Y` where:
 
 * `M.NN` is the semver-minor version of Rust included in the image.
 * `X.Y` is a major.minor version number for changes in this repo.
 
-So for example, `harrisonai/rust:1.56-1.3` would include the Rust toolchain at
+So for example, `ghcr.io/harrison-ai/rust:1.56-1.3` would include the Rust toolchain at
 some version in the `1.56` series, and be the third release of our customizations
 on top of that series.
 
@@ -115,9 +115,9 @@ rules:
 
 We also provide floating semver tags if you don't want to pin to a specific release:
 
-* `harrisonai/rust:M.NN-X` tracks the latest additive updates but should never pull
+* `ghcr.io/harrison-ai/rust:M.NN-X` tracks the latest additive updates but should never pull
   in any breaking changes.
-* `harrisonai/rust:M.NN` tracks all updates other than Rust version changes, and might
+* `ghcr.io/harrison-ai/rust:M.NN` tracks all updates other than Rust version changes, and might
   potentially receive breaking changes in the surrounding tooling.
 
 But please note that assessment of possible breaking changes is based purely on a

--- a/scripts/check-clean-publish.sh
+++ b/scripts/check-clean-publish.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# Check that we can cleanly publish the current git HEAD to dockerhub.
+# Check that we can cleanly publish the current git HEAD to github container registry.
 # This will fail unless we're on a clean checkout of `main`.
 #
 


### PR DESCRIPTION
## Related Tasks

- https://github.com/harrison-ai/platform/issues/145

## What

- Publish docker image to ghcr instead of dockerhub.

Manual steps:
- Make package public (ask an admin to toggle).
- Communicate the change on rust Slack channel to update downstream repos and doco.
- Follow up issue in 1 month to delete the dockerhub image.

## Why

- Decision to migrate from Docker to Github following recent announcement.
- We are at war with docker.
- See https://github.com/harrison-ai/platform/issues/132

## Notes

- Successful action: https://github.com/harrison-ai/dataeng-tooling-rust/actions/runs/4676359371
- Sample package (delete before merge): https://github.com/harrison-ai/dataeng-tooling-rust/pkgs/container/rust
