### PR TITLE
chore: Bump Rust version to 1.72

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
+
+## 1.72-1.0
+
+- Updated Rust version to `1.72.0`
+
 ## 1.70-1.1
 
 - Added cargo machete to find unused dependencies.

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.70.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.72.0-slim AS builder
 
 WORKDIR /build
 
@@ -198,7 +198,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.70.0-slim
+FROM rust:1.72.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,8 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
     gcc-aarch64-linux-gnu \
     linux-libc-dev-amd64-cross \
     gcc-x86-64-linux-gnu \
-    linux-libc-dev-arm64-cross
+    linux-libc-dev-arm64-cross \
+    libfindbin-libs-perl
 
 # Build musl, for both target architectures.
 #
@@ -103,10 +104,10 @@ RUN ln -s /usr/bin/aarch64-linux-gnu-ar ${MUSL_PREFIX}/bin/aarch64-linux-musl-ar
 # with cross-compiled static targets, so we provide it as a pre-built dependency. As with musl itself, 
 # for simplicity and consistency, we ship a build for both of the target architectures.
 
-ENV SSL_VER="1.1.1q"
+ENV SSL_VER="1.1.1w"
 
 RUN curl -sSL https://www.openssl.org/source/openssl-${SSL_VER}.tar.gz > openssl-${SSL_VER}.tar.gz && \
-    echo "d7939ce614029cdff0b6c20f0e2e5703158a489a72b2507b8bd51bf8c8fd10ca" \
+    echo "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" \
     openssl-${SSL_VER}.tar.gz | sha256sum --check
 
 RUN tar -xzf openssl-${SSL_VER}.tar.gz && \


### PR DESCRIPTION
## What

Bumps the Rust version and associated HAI change version to `1.72`

## Why

So we can use the latest Rust stable.