### PR TITLE
chore: Bump Rust to 1.72.1, and update helper tools.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.72-1.1
+
+- Updated Rust version to `1.72.1`
+- Updated `cargo-about` to `0.5.7`
+- Updated `cargo-deny` to `0.14.2`
+- Updated `cargo-make` to `0.37.1`
+- Updated `cargo-release` to `0.24.12`
+
 ## 1.72-1.0
 
 - Updated Rust version to `1.72.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.72.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.72.1-slim AS builder
 
 WORKDIR /build
 
@@ -174,14 +174,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
   # Using `--no-default-features` prevents it trying to compile its own openssl.
-  cargo install --version="0.12.1" --no-default-features cargo-deny && \
+  cargo install --version="0.14.2" --no-default-features cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.5.1" cargo-about && \
+  cargo install --version="0.5.7" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.36.0" cargo-make && \
+  cargo install --version="0.37.1" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.21.0" cargo-release && \
+  cargo install --version="0.24.12" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
   cargo install --version="0.5.0" cargo-machete
 
@@ -199,7 +199,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.72.0-slim
+FROM rust:1.72.1-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
I don't think any of these will be breaking changes in practice, but I haven't really tested them out. Maybe this should be a `1.72-2.0` just in case?