### PR TITLE
feat: Upgrade to Rust 1.73.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.73-0.0
+
+- Updated Rust version to `1.73.0`
+
+
 ## 1.72-1.0
 
 - Updated Rust version to `1.72.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.72.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.73.0-slim AS builder
 
 WORKDIR /build
 
@@ -199,7 +199,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.72.0-slim
+FROM rust:1.73.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Related Tasks

This PR doesn't relate to other tasks.

## Depends on

No other PRs need to be merged first.

## What

This PR is about upgrading our Rust tooling to Rust 1.73.0. :wrench:

## Why

Upgrading to Rust 1.73.0 will allow us to leverage the latest features and improvements in the Rust ecosystem, ensuring our tooling remains up to date and efficient. This is in line with our continuous effort to adhere to the latest industry standards and best practices. :rocket:

The official announcement for Rust 1.73.0 can be found [here](https://blog.rust-lang.org/2023/10/05/Rust-1.73.0.html) and a video summarizing the changes is available [here](https://www.youtube.com/watch?v=xXdfLNIHkPk). :tv:

See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info. :books:
