### PR TITLE
release: Update Rust and packages to 1.75

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,16 +18,16 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up QEMU for Docker
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@v3
         with:
             platforms: arm64
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache docker build artifacts
         uses: actions/cache@v3
@@ -39,7 +39,7 @@ jobs:
             docker-buildx-
 
       - name: Log in to Github Container Registry
-        uses: docker/login-action@d398f07826957cd0a18ea1b059cf1207835e60bc
+        uses: docker/login-action@3d58c274f17dffee475a5520cbe67f0a882c4dbb
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,19 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.75-1.0
+
+- Updated Rust version to `1.75.0`
+- Updated `cargo-deny` to `0.14.3`
+- Updated `cargo-about` to `0.6.0`
+- Updated `cargo-make` to `0.37.5`
+- Updated `cargo-release` to `0.25.2`
+- Updated `cargo-machete` to `0.6.0`
+- Updated GitHub Actions Versions
+
 ## 1.73-0.0
 
 - Updated Rust version to `1.73.0`
-
 
 ## 1.72-1.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.73.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.75.0-slim AS builder
 
 WORKDIR /build
 
@@ -174,16 +174,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
   # Using `--no-default-features` prevents it trying to compile its own openssl.
-  cargo install --version="0.12.1" --no-default-features cargo-deny && \
+  cargo install --version="0.14.3" --no-default-features cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.5.1" cargo-about && \
+  cargo install --version="0.6.0" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.36.0" cargo-make && \
+  cargo install --version="0.37.5" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.21.0" cargo-release && \
+  cargo install --version="0.25.2" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
-  cargo install --version="0.5.0" cargo-machete
+  cargo install --version="0.6.0" cargo-machete
 
 
 ####
@@ -199,7 +199,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.73.0-slim
+FROM rust:1.75.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

- Updated Rust version to `1.75.0`
- Updated `cargo-deny` to `0.14.3`
- Updated `cargo-about` to `0.6.0`
- Updated `cargo-make` to `0.37.5`
- Updated `cargo-release` to `0.25.2`
- Updated `cargo-machete` to `0.6.0`
- Updated GitHub Actions Versions

## Why

To update to the latest Rust version.