### PR TITLE
fix: Allow cargo deny to use default features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.75-1.1
+
+- Bump `cargo-deny` to `0.14.10`
+- Remove `--no-default-features` from the `cargo-deny` install, allowing it to install with default features
+
 ## 1.75-1.0
 
 - Updated Rust version to `1.75.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,7 +173,6 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  # Using `--no-default-features` prevents it trying to compile its own openssl.
   cargo install --version="0.14.10" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.

--- a/Dockerfile
+++ b/Dockerfile
@@ -174,7 +174,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
   # Using `--no-default-features` prevents it trying to compile its own openssl.
-  cargo install --version="0.14.3" --no-default-features cargo-deny && \
+  cargo install --version="0.14.10" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
   cargo install --version="0.6.0" cargo-about && \


### PR DESCRIPTION
## Related Tasks

N/A

## Depends on

N/A

## What

Allows `cargo-deny` to install with its default features.

## Why

One of the feature flags in `cargo-deny`, `reqwest/rustls-tls-webpki-roots`, is used to support the HTTP requests the tool makes. When disabled, it throws the error:

```
[ERROR] failed to fetch advisory database https://github.com/RustSec/advisory-db: An IO error occurred when talking to the server: error sending request for url (https://github.com/RustSec/advisory-db/info/refs?service=git-upload-pack): error trying to connect: invalid URL, scheme is not http
```

Allowing the default flags prevents this error, and also enables the use of OS certificate stores for validating HTTP certificates.