### PR TITLE
chore: Upgrade to rust 1.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ get CI passing and enable the changes to land on `main`.
 ## 1.76-0.0
 
 - Updated Rust version to `1.76.0`
+- Updated `cargo-deny` to `0.14.11`
+- Updated `cargo-about` to `0.6.1`
+- Updated `cargo-make` to `0.37.9`
+- Update `cargo-release` to `0.25.5`
 
 ## 1.75-1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ get CI passing and enable the changes to land on `main`.
 ## 1.76-0.0
 
 - Updated Rust version to `1.76.0`
+- Updated musl to 1.2.4
 - Updated `cargo-deny` to `0.14.11`
 - Updated `cargo-about` to `0.6.1`
 - Updated `cargo-make` to `0.37.9`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.76-0.0
+
+- Updated Rust version to `1.76.0`
+
 ## 1.75-1.1
 
 - Bump `cargo-deny` to `0.14.10`

--- a/Dockerfile
+++ b/Dockerfile
@@ -173,14 +173,14 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.14.10" cargo-deny && \
+  cargo install --version="0.14.11" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.6.0" cargo-about && \
+  cargo install --version="0.6.1" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.5" cargo-make && \
+  cargo install --version="0.37.9" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.25.2" cargo-release && \
+  cargo install --version="0.25.5" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
   cargo install --version="0.6.0" cargo-machete
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,11 +65,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #
 # This will produce `/musl/x86_64/` and `/musl/aarch64/` respectively.
 
-ENV MUSL_VER="1.2.3" \
+ENV MUSL_VER="1.2.4" \
     MUSL_PREFIX=/musl
 
-RUN curl -sSL https://git.musl-libc.org/cgit/musl/snapshot/musl-${MUSL_VER}.tar.gz > musl-${MUSL_VER}.tar.gz && \
-    echo "0504e33a974971ad21cd49213f21a2ff93440f81826b806e57862547abe9b9cf" \
+RUN curl -sSL  https://musl.libc.org/releases/musl-${MUSL_VER}.tar.gz > musl-${MUSL_VER}.tar.gz && \
+    echo "7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039" \
     musl-${MUSL_VER}.tar.gz | sha256sum --check
 
 RUN tar -xzf musl-${MUSL_VER}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.75.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.76.0-slim AS builder
 
 WORKDIR /build
 
@@ -198,7 +198,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.75.0-slim
+FROM rust:1.76.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## Related Tasks

- N/A

## Depends on

- None

## What 🚀

Updated Rust to version 1.76.0. This update introduces ABI compatibility between `char` and `u32`, a new `any::type_name_of_val(&T)` function for improved debugging, and stabilized APIs like `Arc::unwrap_or_clone`, `Result::inspect`, and `Option::inspect`.

## Why 🤔

Upgrading to Rust 1.76.0 allows us to take advantage of the latest language features and improvements. This upgrade aims to enhance our application's performance, security, and maintainability, aligning with our engineering goals.

## Concerns 😕

Compatibility with third-party dependencies and integration issues may arise with Rust 1.76.0. Thorough testing is required to identify and address potential issues.

## Notes 📝

- Please review the [Rust 1.76.0 release notes](https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html) for a comprehensive list of changes.

## Notes 📝 (continued)

- Alongside Rust 1.76.0, we've also updated the following tools to improve our development workflow and ensure compatibility:
  - Updated Rust version to `1.76.0`
  - Updated `cargo-deny` to `0.14.11`
  - Updated `cargo-about` to `0.6.1`
  - Updated `cargo-make` to `0.37.9`
  - Updated `cargo-release` to `0.25.5`
