### PR TITLE
chore: Bump Rust to 1.77.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,17 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.77-1.0
+
+- Updated Rust version to `1.77.1`
+- Updated musl to `1.2.5`
+- Updated OpenSSL to `3.2.1`
+- Updated `cargo-deny` to `1.14.20`
+- Updated `cargo-make` to `0.37.11`
+- Updated `cargo-release` to `0.25.6`
+- Updated `cargo-machete` to `0.6.2`
+- Added `cargo-sort`
+
 ## 1.76-0.0
 
 - Updated Rust version to `1.76.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.76.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.77.1-slim AS builder
 
 WORKDIR /build
 
@@ -65,11 +65,11 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
 #
 # This will produce `/musl/x86_64/` and `/musl/aarch64/` respectively.
 
-ENV MUSL_VER="1.2.4" \
+ENV MUSL_VER="1.2.5" \
     MUSL_PREFIX=/musl
 
 RUN curl -sSL  https://musl.libc.org/releases/musl-${MUSL_VER}.tar.gz > musl-${MUSL_VER}.tar.gz && \
-    echo "7a35eae33d5372a7c0da1188de798726f68825513b7ae3ebe97aaaa52114f039" \
+    echo "a9a118bbe84d8764da0ea0d28b3ab3fae8477fc7e4085d90102b8596fc7c75e4" \
     musl-${MUSL_VER}.tar.gz | sha256sum --check
 
 RUN tar -xzf musl-${MUSL_VER}.tar.gz && \
@@ -104,10 +104,10 @@ RUN ln -s /usr/bin/aarch64-linux-gnu-ar ${MUSL_PREFIX}/bin/aarch64-linux-musl-ar
 # with cross-compiled static targets, so we provide it as a pre-built dependency. As with musl itself, 
 # for simplicity and consistency, we ship a build for both of the target architectures.
 
-ENV SSL_VER="1.1.1w"
+ENV SSL_VER="3.2.1"
 
 RUN curl -sSL https://www.openssl.org/source/openssl-${SSL_VER}.tar.gz > openssl-${SSL_VER}.tar.gz && \
-    echo "cf3098950cb4d853ad95c0841f1f9c6d3dc102dccfcacd521d93925208b76ac8" \
+    echo "83c7329fe52c850677d75e5d0b0ca245309b97e8ecbcfdc1dfdc4ab9fac35b39" \
     openssl-${SSL_VER}.tar.gz | sha256sum --check
 
 RUN tar -xzf openssl-${SSL_VER}.tar.gz && \
@@ -173,16 +173,18 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.14.11" cargo-deny && \
+  cargo install --version="0.14.20" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
   cargo install --version="0.6.1" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.9" cargo-make && \
+  cargo install --version="0.37.11" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.25.5" cargo-release && \
+  cargo install --version="0.25.6" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
-  cargo install --version="0.6.0" cargo-machete
+  cargo install --version="0.6.2" cargo-machete && \
+  # cargo-sort: used for formatting dependencies in Cargo.toml files.
+  cargo install --version="1.0.9" cargo-sort
 
 
 ####
@@ -198,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.76.0-slim
+FROM rust:1.77.1-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

- Updated Rust version to `1.77.1`
- Updated musl to `1.2.5`
- Updated OpenSSL to `3.2.1`
- Updated `cargo-deny` to `1.14.20`
- Updated `cargo-make` to `0.37.11`
- Updated `cargo-release` to `0.25.6`
- Updated `cargo-machete` to `0.6.2`
- Added `cargo-sort`

## Why

So we can release to the next version, and keep everything up to date!


* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.