### PR TITLE
chore: Bump to Rust 1.77.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.77-2.0
+- Updated Rust version to `1.77.2`
+
 ## 1.77-1.0
 
 - Updated Rust version to `1.77.1`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.77.1-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.77.2-slim AS builder
 
 WORKDIR /build
 
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.77.1-slim
+FROM rust:1.77.2-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

Bumps Rust to 1.77.2 because of the recent CVE.

## Why

CVEs are bad!



* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.