### PR TITLE
task: Relax PR check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'Dockerfile'
 
 jobs:
   publish:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,16 @@ jobs:
         with:
             fetch-depth: 0
 
-      - name: Check version number consistency
+      - uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            src:
+              - 'Dockerfile'
+
+      # run only if Dockerfile was changed
+      - if: steps.changes.outputs.src == 'true'
+        name: Check version number consistency
         run: ./scripts/check-pr.sh
 
       - name: Set up QEMU for Docker

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,6 +8,7 @@ name: Check that a PR is ready for merge to main
 on:
   pull_request:
     branches: [main]
+  merge_group:
 
 env:
   GITHUB_BASE_SHA: ${{ github.event.pull_request.base.sha }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,8 +35,6 @@
 #
 ####
 
-
-
 FROM --platform=$BUILDPLATFORM rust:1.77.1-slim AS builder
 
 WORKDIR /build

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,8 @@
 #
 ####
 
+
+
 FROM --platform=$BUILDPLATFORM rust:1.77.1-slim AS builder
 
 WORKDIR /build


### PR DESCRIPTION
## What

This PR relaxes the version bump check to only run if the `Dockerfile` itself has been updated.

## Why

We are getting a lot of false failures in CI for things like bumping the version of a github action, which has no impact on the dockerfile itself.

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.