### PR TITLE
feat: Upgrade to Rust 1.80

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.80-0.0
+
+- Updated Rust version to `1.80.0`
+- Updated `cargo-deny` to `1.16.0`
+- Updated `cargo-make` to `0.37.15`
+
 ## 1.79-0.0
 
 - Updated Rust version to `1.79.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.79.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.80.0-slim AS builder
 
 WORKDIR /build
 
@@ -173,12 +173,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.14.24" cargo-deny && \
+  cargo install --version="0.16.0" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
   cargo install --version="0.6.2" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.13" cargo-make && \
+  cargo install --version="0.37.15" cargo-make && \
   # cargo-release: used for cutting releases.
   cargo install --version="0.25.10" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.79.0-slim
+FROM rust:1.80.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

This PR bumps the version of rust to `1.80`, and updates other rust binaries to their latest versions.

## Why

So we can get all the goodies of 1.80!

