### PR TITLE
chore(deps): FRADATA-1366 Update to Rust 1.82.0 + core-utilities updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,14 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.82-0.0
+
+- Updated Rust version to `1.82.0`
+- Updated `cargo-make` to `0.37.22`
+- Updated `cargo-release` to `0.25.12`
+- Updated `cargo-machete` to `0.7.0`
+- Fix the 3-Musketeers link in `README.md` being a dead link.
+
 ## 1.81-0.0
 
 - Updated Rust version to `1.81.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.81.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.82.0-slim AS builder
 
 WORKDIR /build
 
@@ -178,11 +178,11 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   #              which may be required for compliance with some open-source licenses.
   cargo install --version="0.6.4" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.16" cargo-make && \
+  cargo install --version="0.37.22" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.25.11" cargo-release && \
+  cargo install --version="0.25.12" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
-  cargo install --version="0.6.2" cargo-machete && \
+  cargo install --version="0.7.0" cargo-machete && \
   # cargo-sort: used for formatting dependencies in Cargo.toml files.
   cargo install --version="1.0.9" cargo-sort
 
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.81.0-slim
+FROM rust:1.82.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ docker run
     cargo build
 ```
 
-In repositories using the [three-musketeers pattern](https://3musketeers.io/)
+In repositories using the [three-musketeers pattern](https://3musketeers.pages.dev/guide/getting-started.html)
 you can conveniently automate the environment setup in your `docker-compose.yml`
 like this:
 


### PR DESCRIPTION
## Related Tasks

[FRADATA-1366](https://franklin-ai.atlassian.net/browse/FRADATA-1366)

## Depends on
N/A

## What

Rust has been updated to `1.82.0`. The core utilities that we ship with the container have also been updated to latest.

## Why

House-keeping + dependency management.

## Concerns

None.