### PR TITLE
Chore(deps): Update Rust Toolchain to 1.84.0 and Update Core tooling versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.84-0.0
+- Updated Rust version to `1.84.0`
+- Updated `cargo-make` to `0.37.24`
+- Updated `cargo-deny` to `0.16.4`
+- Updated `cargo-about` to `0.6.6`
+
 ## 1.82-0.0
 
 - Updated Rust version to `1.82.0`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,12 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
-## 1.84-0.0
-- Updated Rust version to `1.84.0`
+## 1.85-0.0
+- Updated Rust version to `1.85.0`
 - Updated `cargo-make` to `0.37.24`
-- Updated `cargo-deny` to `0.16.4`
+- Updated `cargo-deny` to `0.18.0`
 - Updated `cargo-about` to `0.6.6`
+- Updated `cargo-release` to `0.25.17`
 
 ## 1.82-0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.82.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.84.0-slim AS builder
 
 WORKDIR /build
 
@@ -173,12 +173,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.16.1" cargo-deny && \
+  cargo install --version="0.16.4" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.6.4" cargo-about && \
+  cargo install --version="0.6.6" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.22" cargo-make && \
+  cargo install --version="0.37.24" cargo-make && \
   # cargo-release: used for cutting releases.
   cargo install --version="0.25.12" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.82.0-slim
+FROM rust:1.84.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.84.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.85.0-slim AS builder
 
 WORKDIR /build
 
@@ -45,8 +45,8 @@ WORKDIR /build
 ## different $TARGETPLATFORM builds.
 
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  apt-get update  && \
-  apt-get install -y --no-install-recommends \
+    apt-get update  && \
+    apt-get install -y --no-install-recommends \
     curl \
     make \
     pkg-config \
@@ -170,21 +170,21 @@ RUN echo "[build]\ntarget=\"`./docker-target-triple`\"" > ${CARGO_HOME}/config.t
 # build...but cargo doesn't seem to have a separate "update the registry cache" operation.
 
 RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
-  --mount=type=cache,target=/build/target \
-  export CARGO_BUILD_TARGET=`./docker-target-triple` && \
-  # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.16.4" cargo-deny && \
-  # cargo-about: used for generating license files for distribution to consumers,
-  #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.6.6" cargo-about && \
-  # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.24" cargo-make && \
-  # cargo-release: used for cutting releases.
-  cargo install --version="0.25.12" cargo-release && \
-  # cargo-machete: used for finding unused dependencies.
-  cargo install --version="0.7.0" cargo-machete && \
-  # cargo-sort: used for formatting dependencies in Cargo.toml files.
-  cargo install --version="1.0.9" cargo-sort
+    --mount=type=cache,target=/build/target \
+    export CARGO_BUILD_TARGET=`./docker-target-triple` && \
+    # cargo-deny: used for dependency license and security checks.
+    cargo install --version="0.18.0" cargo-deny && \
+    # cargo-about: used for generating license files for distribution to consumers,
+    # which may be required for compliance with some open-source licenses.
+    cargo install --version="0.6.6" cargo-about && \
+    # cargo-make: used for defining dev & build tasks.
+    cargo install --version="0.37.24" cargo-make && \
+    # cargo-release: used for cutting releases.
+    cargo install --version="0.25.17" cargo-release && \
+    # cargo-machete: used for finding unused dependencies.
+    cargo install --version="0.7.0" cargo-machete && \
+    # cargo-sort: used for formatting dependencies in Cargo.toml files.
+    cargo install --version="1.0.9" cargo-sort
 
 
 ####
@@ -200,12 +200,12 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.84.0-slim
+FROM rust:1.85.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \
-  apt-get update  && \
-  apt-get install -y --no-install-recommends \
+    apt-get update  && \
+    apt-get install -y --no-install-recommends \
     jq \
     curl \
     make \
@@ -222,8 +222,8 @@ RUN rustup component add clippy
 
 # Our two main compilation targets.
 RUN rustup target add \
-  aarch64-unknown-linux-musl \
-  x86_64-unknown-linux-musl
+    aarch64-unknown-linux-musl \
+    x86_64-unknown-linux-musl
 
 # Copy the built musl system-level dependencies and associated config.
 ENV MUSL_PREFIX=/musl
@@ -250,13 +250,13 @@ COPY --from=builder ${CARGO_HOME}/config.toml ${CARGO_HOME}/config.toml
 
 # Copy the built additional cargo tooling.
 COPY --from=builder \
-  ${CARGO_HOME}/bin/cargo-deny \
-  ${CARGO_HOME}/bin/cargo-about \
-  ${CARGO_HOME}/bin/cargo-make \
-  ${CARGO_HOME}/bin/cargo-release \
-  ${CARGO_HOME}/bin/cargo-machete \
-  ${CARGO_HOME}/bin/cargo-sort \
-  ${CARGO_HOME}/bin/
+    ${CARGO_HOME}/bin/cargo-deny \
+    ${CARGO_HOME}/bin/cargo-about \
+    ${CARGO_HOME}/bin/cargo-make \
+    ${CARGO_HOME}/bin/cargo-release \
+    ${CARGO_HOME}/bin/cargo-machete \
+    ${CARGO_HOME}/bin/cargo-sort \
+    ${CARGO_HOME}/bin/
 
 # Add additional not-natively-compiled cargo tooling.
 COPY ./scripts/cargo-hai-all-checks ${CARGO_HOME}/bin/

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: .built.amd64.image .built.arm64.image
 	docker buildx build $(BUILDX_CACHE_FROM) $(BUILDX_CACHE_TO) --platform  linux/amd64,linux/arm64 .
 
 .built.%.image.tar: .built.images
-	# The `.built.iamges` dependency will have exported the cache, don't waste time writing it out again.
+	# The `.built.images` dependency will have exported the cache, don't waste time writing it out again.
 	# It seems that we still need to *read* from the cache again though, at least in CI.
 	docker buildx build $(BUILDX_CACHE_FROM) --platform "linux/$*" --output "type=docker,dest=$@" .
 


### PR DESCRIPTION
## Related Tasks
N / A

## Depends on

No other PR's

## What

Update Rust toolchain/compiler to `1.84.0` and minor version bumps for core-tools.

## Why

To stay updated with mainline Rust.

## Concerns

None.

## Notes
This section is also optional and should include anything else that you would like to discuss in the PR review that is not captured elsewhere.

* See the [data engineering handbook](https://dataengineering.harrisonai.io/pages/source_control.html#anatomy-of-a-pull-request) for more info.