### PR TITLE
task: Upgrade to 1.85.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ Every commit to `main` in this project creates a new release and hence must have
 a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
+## 1.85-0.0
+
+- Updated Rust version to `1.85.0`
+- Updated `cargo-deny` to `0.18.1`
+- Updated `cargo-about` to `0.7.0`
+- Updated `cargo-make` to `0.37.24`
+- Updated `cargo-release` to `0.25.17`
+- Updated `cargo-machete` to `0.8.0`
 
 ## 1.82-0.1
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.82.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.85.0-slim AS builder
 
 WORKDIR /build
 
@@ -173,16 +173,16 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
   --mount=type=cache,target=/build/target \
   export CARGO_BUILD_TARGET=`./docker-target-triple` && \
   # cargo-deny: used for dependency license and security checks.
-  cargo install --version="0.16.1" cargo-deny && \
+  cargo install --version="0.18.1" cargo-deny && \
   # cargo-about: used for generating license files for distribution to consumers,
   #              which may be required for compliance with some open-source licenses.
-  cargo install --version="0.6.4" cargo-about && \
+  cargo install --version="0.7.0" cargo-about && \
   # cargo-make: used for defining dev & build tasks.
-  cargo install --version="0.37.22" cargo-make && \
+  cargo install --version="0.37.24" cargo-make && \
   # cargo-release: used for cutting releases.
-  cargo install --version="0.25.12" cargo-release && \
+  cargo install --version="0.25.17" cargo-release && \
   # cargo-machete: used for finding unused dependencies.
-  cargo install --version="0.7.0" cargo-machete && \
+  cargo install --version="0.8.0" cargo-machete && \
   # cargo-sort: used for formatting dependencies in Cargo.toml files.
   cargo install --version="1.0.9" cargo-sort
 
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.82.0-slim
+FROM rust:1.85.0-slim
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ build: .built.amd64.image .built.arm64.image
 	docker buildx build $(BUILDX_CACHE_FROM) $(BUILDX_CACHE_TO) --platform  linux/amd64,linux/arm64 .
 
 .built.%.image.tar: .built.images
-	# The `.built.iamges` dependency will have exported the cache, don't waste time writing it out again.
+	# The `.built.images` dependency will have exported the cache, don't waste time writing it out again.
 	# It seems that we still need to *read* from the cache again though, at least in CI.
 	docker buildx build $(BUILDX_CACHE_FROM) --platform "linux/$*" --output "type=docker,dest=$@" .
 


### PR DESCRIPTION
## What

This PR releases a version of the docker image supporting rust `1.85.0`.

## Why

This is the latest release that we want to be using.
