### PR TITLE
task: Explicitly use bookworm image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ a new version number. Fill in an appropriate changelog entry in this file to
 get CI passing and enable the changes to land on `main`.
 ``
 
+## 1.90-0.1
+
+- Explicity use the `bookworm` base image
+
 ## 1.90-0.0
 
 - Updated Rust version to `1.90.0`

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@
 #
 ####
 
-FROM --platform=$BUILDPLATFORM rust:1.90.0-slim AS builder
+FROM --platform=$BUILDPLATFORM rust:1.90.0-slim-bookworm AS builder
 
 WORKDIR /build
 
@@ -200,7 +200,7 @@ RUN --mount=type=cache,target=/usr/local/cargo/registry,sharing=locked \
 #
 ####
 
-FROM rust:1.90.0-slim
+FROM rust:1.90.0-slim-bookworm
 
 # Install extra system dependencies not included in the slim base image.
 RUN  --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
## What

This PR updates the base image to explicitly use the `bookworm` based release.

## Why

The following recent change updated the default image to use `trixie`. We ended up taking this update without realising. This change makes our dependency on `bookworm` explicit.

https://github.com/rust-lang/docker-rust/pull/246/files
